### PR TITLE
AndroidManifest Exported:Android 12 Kompatibilität

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
         <activity
             android:name=".LoginActivity"
             android:label="@string/app_name"
+            android:exported="true"
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Um "Manifest merger failed : android:exported needs to be explicitly specified for element <activity#de.blitzdose.dualisnotifier.LoginActivity>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details." zu beheben